### PR TITLE
Set timeout for tests on puppeteer to 0 (infinite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## NEXT
+
+Set timeout for tests on puppeteer to 0 (infinite)
+
 ## 1.0.0
 
 Breaking: Chrome driver now runs headless unless you set `TEST_BROWSER_VISIBLE=1`

--- a/browser/puppeteer.js
+++ b/browser/puppeteer.js
@@ -49,7 +49,7 @@ export default function startPuppeteer({
 
     await page.goto(process.env.ROOT_URL);
 
-    await page.waitFor(() => window.testsDone);
+    await page.waitFor(() => window.testsDone, { timeout: 0 });
     const testFailures = await page.evaluate('window.testFailures');
 
     await page.close();


### PR DESCRIPTION
Before I introduced this code, I got the following message after 30 seconds, which is the default timeout for the `waitFor()` function:

```
(node:59290) UnhandledPromiseRejectionWarning: Error: waiting for function failed: timeout 30000ms exceeded
    at Timeout.WaitTask._timeoutTimer.setTimeout (/projects/test/node_modules/puppeteer/lib/FrameManager.js:844:60)
    at ontimeout (timers.js:482:11)
    at tryOnTimeout (timers.js:317:5)
    at Timer.listOnTimeout (timers.js:277:5)
 => awaited here:
    at Function.Promise.await (/Users/work/.meteor/packages/promise/.0.10.2.4xp0lj.vhtlc++os+web.browser+web.cordova/npm/node_modules/meteor-promise/promise_server.js:56:12)
    at Promise.asyncApply (packages/meteortesting:browser-tests/browser/puppeteer.js:52:5)
    at /Users/work/.meteor/packages/promise/.0.10.2.4xp0lj.vhtlc++os+web.browser+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
(node:59290) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 35)
(node:59290) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Even if it looks, this is not related to any currently issue reported earlier. I lately ran into it and thought this couldn't be much of an effort to fix 😉 