### PR TITLE
Avoid "WebSocket is closed before the connection is established." error in the end of a test-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## NEXT
+
+Removed explicit closing of page to avoid "WebSocket is closed before the connection is established." error
+
 ## 1.0.0
 
 Breaking: Chrome driver now runs headless unless you set `TEST_BROWSER_VISIBLE=1`

--- a/browser/puppeteer.js
+++ b/browser/puppeteer.js
@@ -52,7 +52,6 @@ export default function startPuppeteer({
     await page.waitFor(() => window.testsDone);
     const testFailures = await page.evaluate('window.testFailures');
 
-    await page.close();
     await browser.close();
 
     done(testFailures);


### PR DESCRIPTION
I found out that the sometimes occurring error `WebSocket is closed before the connection is established.` can be avoided by not explicitly closing the page but the browser directly.

The error message normally looks like this:

```
--------------------------------
----- RUNNING CLIENT TESTS -----
--------------------------------
Kadira: completed instrumenting the app
HeadlessChrome/68.0.3419.0
=> Started your app.

=> App running at: http://localhost:3100/
Kadira: authentication failed - check your appId & appSecret
1..5
ok 1 sandbox executes code
ok 2 sandbox can run with an object as `this`
ok 3 sandbox uses an empty string as `this` if not defined
ok 4 sandbox can run with undefined arguments
ok 5 sandbox returns a function with no return if functionBody is empty
# tests 5
# pass 5
# fail 0
(node:58667) UnhandledPromiseRejectionWarning: Error: Protocol error (Runtime.evaluate): Session closed. Most likely the page has been closed.
    at CDPSession.send (/meteor-project/node_modules/puppeteer/lib/Connection.js:187:29)
    at ExecutionContext.evaluateHandle (/meteor-project/node_modules/puppeteer/lib/ExecutionContext.js:67:77)
    at ExecutionContext.evaluate (/meteor-project/node_modules/puppeteer/lib/ExecutionContext.js:46:31)
    at Frame.evaluate (/meteor-project/node_modules/puppeteer/lib/FrameManager.js:326:20)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
 => awaited here:
    at Function.Promise.await (/Users/test/.meteor/packages/promise/.0.10.2.4xp0lj.vhtlc++os+web.browser+web.cordova/npm/node_modules/meteor-promise/promise_server.js:56:12)
    at Promise.asyncApply (packages/meteortesting:browser-tests/browser/puppeteer.js:48:13)
    at /Users/test/.meteor/packages/promise/.0.10.2.4xp0lj.vhtlc++os+web.browser+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
(node:58667) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:58667) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
=> Exited with code: 0
```

The message the system tries to report while being killed off is:
```
ConsoleMessage {
  _type: 'warning',
  _text: 'WebSocket connection to \'ws://localhost:3100/sockjs/473/wltn30p9/websocket\' failed: WebSocket is closed before the connection is established.',
  _args: [] }
