### PR TITLE
Close #18: allow additional arguments for chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ $ TEST_BROWSER_DRIVER=chrome meteor test --once --driver-package <your package n
 
 Chrome will run headless unless you export `TEST_BROWSER_VISIBLE=1`.
 
+Additional command-line arguments for Chrome can be specified using the `TEST_CHROME_ARGS` environment variable. Multiple arguments are supported, separated by spaces. If you need to include a space inside an individual argument, use `%20` instead of the space.
+
 Meteor < 1.6:
 
 **NOTE: Currently you must pin to exactly version 3.0.0-beta-2 of selenium-webdriver for earlier versions of Meteor because the latest webdriver package only works on Node 6.x+. The `-E` in the command below is important!**

--- a/browser/chromedriver.js
+++ b/browser/chromedriver.js
@@ -43,6 +43,14 @@ export default function startChrome({
   // so we need to set browser logging level to "ALL".
   const options = new chrome.Options();
   if (!process.env.TEST_BROWSER_VISIBLE) options.addArguments('--headless');
+  // Pass additional chrome options as appropriate
+  if (process.env.TEST_CHROME_ARGS) {
+    // Convert any appearances of "%20" to " " so as to support spaces in arguments if necessary
+    let additionalOptions = process.env.TEST_CHROME_ARGS
+        .split(/\s+/)
+        .map((arg) => arg.replace(/%20/g, " "));
+    options.addArguments.apply(options, additionalOptions);
+  }
   driver = new webdriver.Builder().forBrowser('chrome').withCapabilities(options.toCapabilities()).setLoggingPrefs({ browser: 'ALL' }).build();
 
   // Can't hide the window but can move it off screen


### PR DESCRIPTION
Resolves https://github.com/meteortesting/meteor-browser-tests/issues/18 .

It's a little more complicated than I would have liked because I figured there should be a way to specify multiple arguments, and the way that spawning processes from node works it's not equivalent to have, for example `--no-sandbox --version` as a single argument versus having `--no-sandbox` and `--version` as separate arguments.

I decided to split on whitespace, and support a way for users to escape spaces in the unlikely case that someone actually needs a space inside of a single argument.  Open to suggestions for other ways to do it (or just to do less).