### PR TITLE
Add env var to change nightmare's wait() timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ $ TEST_BROWSER_DRIVER=nightmare meteor test --once --driver-package <your packag
 
 You can export `TEST_BROWSER_VISIBLE=1` to show the Electron window while tests run.
 
+Nightmare's default `wait()` timeout is 30 seconds. It may not be enough to run all your tests. You can change it using the environment variable `NIGHTMARE_WAIT_TIMEOUT=60000` to set it to 60 seconds, for example.
+
 ### PhantomJS
 
 Support for PhantomJS has been deprecated because it's development is suspended. For more information on why it got suspended, please take a look at [the repository](https://github.com/ariya/phantomjs)

--- a/browser/nightmare.js
+++ b/browser/nightmare.js
@@ -33,7 +33,10 @@ export default function startNightmare({
     throw new Error('When running tests with TEST_BROWSER_DRIVER=nightmare, you must first "npm i --save-dev nightmare"');
   }
 
-  nightmare = Nightmare({ show });
+  nightmare = Nightmare({
+    show,
+    waitTimeout: process.env.NIGHTMARE_WAIT_TIMEOUT || 30000,
+  });
 
   let testFailures;
   nightmare

--- a/browser/nightmare.js
+++ b/browser/nightmare.js
@@ -35,7 +35,8 @@ export default function startNightmare({
 
   nightmare = Nightmare({
     show,
-    waitTimeout: process.env.NIGHTMARE_WAIT_TIMEOUT || 30000,
+    // use nightmare's default timeout if no env var is found
+    waitTimeout: process.env.NIGHTMARE_WAIT_TIMEOUT || null,
   });
 
   let testFailures;


### PR DESCRIPTION
Our tests started to take more than 30 seconds in our build environment. Nightmare's default timeout is not enough to run all of them. Tests continue to run, but `nightmare.end()` is never called due to a timeout and the process hangs, halting our build pipeline forever.

This adds an env var `NIGHTMARE_WAIT_TIMEOUT` to allow changing the `wait()` timeout of the nightmare instance.

Cheers!