### PR TITLE
Increase default waitTimeout for Nightmare

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ $ TEST_BROWSER_DRIVER=nightmare meteor test --once --driver-package <your packag
 
 You can export `TEST_BROWSER_VISIBLE=1` to show the Electron window while tests run.
 
-Nightmare's default `wait()` timeout is 30 seconds. It may not be enough to run all your tests. You can change it using the environment variable `NIGHTMARE_WAIT_TIMEOUT=60000` to set it to 60 seconds, for example.
-
 ### PhantomJS
 
 Support for PhantomJS has been deprecated because it's development is suspended. For more information on why it got suspended, please take a look at [the repository](https://github.com/ariya/phantomjs)

--- a/browser/nightmare.js
+++ b/browser/nightmare.js
@@ -11,6 +11,7 @@
 // HINT: If not working, run with `DEBUG=nightmare:*,electron:*` to see nightmare errors
 
 const show = !!process.env.TEST_BROWSER_VISIBLE;
+const TWENTY_DAYS = 1000 * 60 * 60 * 24 * 20;
 
 let nightmare;
 
@@ -37,8 +38,8 @@ export default function startNightmare({
     show,
     // Controls maximum time client tests can take for Meteor to still
     // automatically exit after they complete.
-    // Defaults to 30 minutes
-    waitTimeout: process.env.NIGHTMARE_WAIT_TIMEOUT || 1000 * 60 * 30,
+    // Defaults to 20 days
+    waitTimeout: process.env.NIGHTMARE_WAIT_TIMEOUT || TWENTY_DAYS,
   });
 
   let testFailures;

--- a/browser/nightmare.js
+++ b/browser/nightmare.js
@@ -39,7 +39,7 @@ export default function startNightmare({
     // Controls maximum time client tests can take for Meteor to still
     // automatically exit after they complete.
     // Defaults to 20 days
-    waitTimeout: process.env.NIGHTMARE_WAIT_TIMEOUT || TWENTY_DAYS,
+    waitTimeout: TWENTY_DAYS,
   });
 
   let testFailures;

--- a/browser/nightmare.js
+++ b/browser/nightmare.js
@@ -35,8 +35,10 @@ export default function startNightmare({
 
   nightmare = Nightmare({
     show,
-    // use nightmare's default timeout if no env var is found
-    waitTimeout: process.env.NIGHTMARE_WAIT_TIMEOUT || null,
+    // Controls maximum time client tests can take for Meteor to still
+    // automatically exit after they complete.
+    // Defaults to 30 minutes
+    waitTimeout: process.env.NIGHTMARE_WAIT_TIMEOUT || 1000 * 60 * 30,
   });
 
   let testFailures;


### PR DESCRIPTION
When `.wait` times out, `meteortesting:mocha` will not automatically exit the app after the tests finish. This PR increases the default to 30 minutes to reduce the possibility of an app encountering this. 