### PR TITLE
browser puppeteer replace deprecated page.waitFor with page.waitForFunction

### DIFF
--- a/browser/puppeteer.js
+++ b/browser/puppeteer.js
@@ -61,7 +61,7 @@ export default function startPuppeteer({
 
     await page.goto(process.env.ROOT_URL);
 
-    await page.waitFor(() => window.testsDone, { timeout: 0 });
+    await page.waitForFunction(() => window.testsDone, { timeout: 0 });
     const testFailures = await page.evaluate('window.testFailures');
 
     await page.close();


### PR DESCRIPTION
The puppeteer API will soon remove `page.waitFor` as described here: https://github.com/puppeteer/puppeteer/issues/6214

This PR replaces [`page.waitFor`](https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#pagewaitforselectororfunctionortimeout-options-args) with [`page.waitForFunction`](https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#pagewaitforfunctionpagefunction-options-args).