### PR TITLE
Set higher default and allow configuring puppeteer protocol timeout

### DIFF
--- a/browser/puppeteer.js
+++ b/browser/puppeteer.js
@@ -9,6 +9,8 @@
  */
 const util = require('util');
 
+const TWENTY_DAYS = 1000 * 60 * 60 * 24 * 20;
+
 export default function startPuppeteer({
   stdout,
   stderr,
@@ -31,6 +33,7 @@ export default function startPuppeteer({
     const browser = await puppeteer.launch({
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
       headless: 'new',
+      protocolTimeout: TWENTY_DAYS,
     });
     console.log(await browser.version());
     const page = await browser.newPage();

--- a/browser/puppeteer.js
+++ b/browser/puppeteer.js
@@ -33,7 +33,9 @@ export default function startPuppeteer({
     const browser = await puppeteer.launch({
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
       headless: 'new',
-      protocolTimeout: TWENTY_DAYS,
+      protocolTimeout: process.env.PUPPETEER_PROTOCOL_TIMEOUT === undefined
+        ? TWENTY_DAYS
+        : Number.parseInt(process.env.PUPPETEER_PROTOCOL_TIMEOUT, 10),
     });
     console.log(await browser.version());
     const page = await browser.newPage();


### PR DESCRIPTION
I believe this should fix https://github.com/Meteor-Community-Packages/meteor-mocha/issues/104.