### PR TITLE
readme: Revise Puppeteer version compatibility details

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ When using your test driver package, you will need to install the necessary NPM 
 
 ### Puppeteer
 
-`puppeteer@^19.11.1` is the latest version with Node 14 compatibility (Meteor 2.x is set to use Node.js version 14.x by default).
+We support the latest `puppeteer` version with Node 22 compatibility. Meteor 2.x users should be aware, that this is set to use Node.js version 14.x by default, which is only works with `puppeteer@19.11.1`.
 
 ```bash
-$ npm i --save-dev puppeteer@^19.11.1
+$ npm i --save-dev puppeteer@latest
 $ TEST_BROWSER_DRIVER=puppeteer meteor test --once --driver-package <your package name>
 ```
 


### PR DESCRIPTION
Update Puppeteer version information for Meteor 3.x and Meteor 2.x users.